### PR TITLE
add link to institute to badge

### DIFF
--- a/src/app/catalog/components/badge-catalog/badge-catalog.component.html
+++ b/src/app/catalog/components/badge-catalog/badge-catalog.component.html
@@ -68,6 +68,7 @@
 					[badgeTitle]="badge.name"
 					[badgeImage]="badge.image"
 					[badgeDescription]="badge.description"
+					[issuerSlug]="badge.issuerSlug"
 					[badgeSlug]="badge.slug"
 					[issuerTitle]="badge.issuerName ? badge.issuerName : badge.issuer.name"
 					[badgeIssueDate]="badge.createdAt"

--- a/src/app/common/components/bg-badgecard.ts
+++ b/src/app/common/components/bg-badgecard.ts
@@ -20,7 +20,7 @@ declare function require(path: string): string;
 			</div>
 			<a *ngIf="badgeSlug" class="badgecard-x-title u-text-breakword" [routerLink]="['../earned-badge', badgeSlug]">{{ badgeTitle }}</a>
 			<a *ngIf="publicUrl" class="badgecard-x-title" [href]="publicUrl">{{ badgeTitle }}</a>
-			<div class="badgecard-x-issuer">{{ issuerTitle }}</div>
+			<a class="badgecard-x-issuer" [routerLink]="['../../public/issuers', issuerSlug]">{{ issuerTitle }}</a>
 			<p class="badgecard-x-desc" [truncatedText]="badgeDescription" [maxLength]="100"></p>
 		</div>
 		<div class="badgecard-x-footer">
@@ -45,6 +45,7 @@ export class BgBadgecard {
 	readonly badgeLoadingImageUrl = require('../../../breakdown/static/images/badge-loading.svg');
 	readonly badgeFailedImageUrl = require('../../../breakdown/static/images/badge-failed.svg');
 	@Input() badgeSlug: string;
+	@Input() issuerSlug: string;
 	@Input() publicUrl: string;
 	@Input() badgeImage: string;
 	@Input() badgeTitle: string;

--- a/src/app/recipient/components/recipient-earned-badge-list/recipient-earned-badge-list.component.html
+++ b/src/app/recipient/components/recipient-earned-badge-list/recipient-earned-badge-list.component.html
@@ -118,6 +118,7 @@
 							[badgeIssueDate]="badgeResult?.badge?.issueDate"
 							[mostRelevantStatus]="badgeResult.badge.mostRelevantStatus"
 							[issuerTitle]="badgeResult.badge.badgeClass.issuer.name"
+							[issuerSlug]="issuerIdToSlug(badgeResult.badge.badgeClass.issuer.id)"
 							[badgeSlug]="badgeResult.badge.slug"
 							(shareClicked)="shareBadge(badgeResult.badge)"
 						></bg-badgecard>
@@ -141,6 +142,7 @@
 								[badgeDescription]="badge.badgeClass.description"
 								[badgeIssueDate]="badge.issueDate"
 								[mostRelevantStatus]="badge.mostRelevantStatus"
+								[issuerSlug]="issuerIdToSlug(issuerGroup.issuerId)"
 								[issuerTitle]="badge.badgeClass.issuer.name"
 								[badgeSlug]="badge.slug"
 								(shareClicked)="shareBadge(badge)"
@@ -166,7 +168,10 @@
 						<ng-template ngFor let-issuerGroup [ngForOf]="issuerResults" let-i="index">
 							<tr class="datatable-x-row" *ngIf="groupByIssuer">
 								<th class="datatable-x-inlineheader" scope="row" colspan="4">
-									{{ issuerGroup.issuer.name }}
+									<a class="u-text u-text-link u-text-breakword"
+									   [routerLink]="['../../public/issuers', issuerIdToSlug(issuerGroup.issuerId)]">
+										{{ issuerGroup.issuer.name }}
+									</a>
 								</th>
 							</tr>
 							<!-- Badges -->
@@ -183,9 +188,8 @@
 												[error-src]="badgeFailedImageUrl"
 												[loaded-src]="badge.image"
 											/>
-											<a
-												class="u-text u-text-link u-text-breakword"
-												[routerLink]="['../earned-badge', badge.slug]"
+											<a class="u-text u-text-link u-text-breakword"
+											   [routerLink]="['../earned-badge', badge.slug]"
 												>{{ badge.badgeClass.name }}</a
 											>
 											<div
@@ -198,7 +202,13 @@
 											</div>
 										</div>
 									</td>
-									<td class="datatable-x-cell u-text-body">{{ badge.badgeClass.issuer.name }}</td>
+									<td class="datatable-x-cell u-text-body">
+										<a
+											class="u-text u-text-link u-text-breakword"
+											[routerLink]="['../../public/issuers', issuerIdToSlug(issuerGroup.issuerId)]">
+											{{ issuerGroup.issuer.name }}
+										</a>
+									</td>
 									<td class="datatable-x-cell u-text-body">
 										<time [date]="badge?.issueDate" format="mediumDate"></time>
 									</td>

--- a/src/app/recipient/components/recipient-earned-badge-list/recipient-earned-badge-list.component.ts
+++ b/src/app/recipient/components/recipient-earned-badge-list/recipient-earned-badge-list.component.ts
@@ -192,6 +192,15 @@ export class RecipientEarnedBadgeListComponent extends BaseAuthenticatedRoutable
 		this.updateResults();
 	}
 
+	issuerIdToSlug(issuerId) {
+		if(issuerId.startsWith("http")) {
+			let splitted = (issuerId.split(/[/.\s]/))
+			return splitted[splitted.length-1]
+		} else {
+			return issuerId
+		}
+	}
+
 	private updateResults() {
 		// Clear Results
 		this.badgeResults.length = 0;

--- a/src/breakdown/static/css/re-style.css
+++ b/src/breakdown/static/css/re-style.css
@@ -42,3 +42,7 @@
 .andere {
     background: #3bb2d0;
 }
+
+.badgecard-x-issuer:hover {
+    text-decoration: underline;
+}


### PR DESCRIPTION
This is my solution to adding urls to the institute to a badge. It works both in the Rucksack and in the Badges Tab. 

Problematic was that request for badges of the backpack returns issuers without a slug. My first thought was, that I could just use the issuerId to make a request to the backend to get the full issuer, but that response doesnt have a slug either. So I implemented a kind of wonky solution, where I split the id-string of the issuer and take the last part, which is always the slug (or so I hope). Could be problematic if the format of the id ever changes, but currently it works. Maybe it would be better to change the backend so that the request returns the slug (I tried that too, but Django is confusing me still).

One thing I am not sure about is the css. Currently the institute link looks like text and not a link.