### PR TITLE
Group badges by issuer

### DIFF
--- a/src/app/catalog/components/badge-catalog/badge-catalog.component.html
+++ b/src/app/catalog/components/badge-catalog/badge-catalog.component.html
@@ -31,6 +31,12 @@
 						<svg class="forminput-x-icon" icon="icon_search"></svg>
 					</div>
 				</div>
+				<div class="l-actionbar-x-groupby" *ngIf="badgesDisplay != 'map'">
+					<label class="checkbox checkbox-small">
+						<input name="groupby" type="checkbox" [(ngModel)]="groupByIssuer" />
+						<span class="checkbox-x-text">Nach Institution grupppieren</span>
+					</label>
+				</div>
 				<div class="viewtoggle l-actionbar-x-viewtoggle"
 				[class.viewtoggle-is-listview]="order == 'desc'">
 					<label class="viewtoggle-x-grid" (click)='changeOrder("asc")'>
@@ -60,22 +66,49 @@
 			<div class="open-legend-button">
 				<a (click)="openLegend()">Was bedeuten die Rahmen und Farben?</a>
 			</div>
-
-			<div class="l-grid l-grid-large">
-				<!-- TODO: Fix the badgecard link for sharing and routing -->
-				<bg-badgecard
-					*ngFor="let badge of badgeResults"
-					[badgeTitle]="badge.name"
-					[badgeImage]="badge.image"
-					[badgeDescription]="badge.description"
-					[badgeSlug]="badge.slug"
-					[issuerTitle]="badge.issuerName ? badge.issuerName : badge.issuer.name"
-					[badgeIssueDate]="badge.createdAt"
-					public="true"
-					[publicUrl]="badge.url"
-					[badgeClass]="true"
-				></bg-badgecard>
-			</div>
+			<ng-container *ngIf="!groupByIssuer">
+				<div class="l-grid l-grid-large">
+					<!-- TODO: Fix the badgecard link for sharing and routing -->
+					<bg-badgecard
+						*ngFor="let badge of badgeResults"
+						[badgeTitle]="badge.name"
+						[badgeImage]="badge.image"
+						[badgeDescription]="badge.description"
+						[badgeSlug]="badge.slug"
+						[issuerTitle]="badge.issuerName ? badge.issuerName : badge.issuer.name"
+						[badgeIssueDate]="badge.createdAt"
+						public="true"
+						[publicUrl]="badge.url"
+						[badgeClass]="true"
+					></bg-badgecard>
+				</div>
+			</ng-container>
+			<ng-container *ngIf="groupByIssuer">
+				<ng-container *ngFor="let issuerGroup of badgeResultsByIssuer">
+					<h3 class="u-text-h3-semibold u-margin-bottom2x u-margin-top6x u-text-dark1">
+						{{ issuerGroup.issuerName }}
+						<span class="u-text-small-semibold-caps u-text-dark4 u-margin-left2x"
+							>{{ issuerGroup.badges.length }}
+							{{ issuerGroup.badges.length == 1 ? 'Badge' : 'Badges' }}</span
+						>
+					</h3>
+					<div class="l-grid l-grid-large">
+						<!-- TODO: Fix the badgecard link for sharing and routing -->
+						<bg-badgecard
+							*ngFor="let badge of issuerGroup.badges"
+							[badgeTitle]="badge.name"
+							[badgeImage]="badge.image"
+							[badgeDescription]="badge.description"
+							[badgeSlug]="badge.slug"
+							[issuerTitle]="badge.issuerName ? badge.issuerName : badge.issuer.name"
+							[badgeIssueDate]="badge.createdAt"
+							public="true"
+							[publicUrl]="badge.url"
+							[badgeClass]="true"
+						></bg-badgecard>
+					</div>
+				</ng-container>
+			</ng-container>
 		</section>
 	</ng-template>
 </div>

--- a/src/app/catalog/components/badge-catalog/badge-catalog.component.ts
+++ b/src/app/catalog/components/badge-catalog/badge-catalog.component.ts
@@ -32,7 +32,7 @@ export class BadgeCatalogComponent extends BaseRoutableComponent implements OnIn
 	// issuers: Issuer[] = null;
 	badges: BadgeClass[] = null;
 	badgeResults: BadgeClass[] = null;
-	badgeResultsByIssuer: MatchingIssuerCategory[] = [];
+	badgeResultsByIssuer: MatchingBadgeIssuer[] = [];
 	order = 'asc';
 	//issuerToBadgeInfo: {[issuerId: string]: IssuerBadgesInfo} = {};
 
@@ -145,14 +145,14 @@ export class BadgeCatalogComponent extends BaseRoutableComponent implements OnIn
 		// 	that.badgeResults.push(item);
 		// }
 
-		var addIssuerToResultsByCategory = function(item){
+		var addBadgeToResultsByIssuer = function(item){
 
 			that.badgeResults.push(item);
 			
 			let issuerResults = badgeResultsByIssuerLocal[item.issuerName];
 			
 			if (!issuerResults) {
-				issuerResults = badgeResultsByIssuerLocal[item.issuerName] = new MatchingIssuerCategory(
+				issuerResults = badgeResultsByIssuerLocal[item.issuerName] = new MatchingBadgeIssuer(
 					item.issuerName,
 					""
 				);
@@ -163,11 +163,6 @@ export class BadgeCatalogComponent extends BaseRoutableComponent implements OnIn
 
 			issuerResults.addBadge(item);
 
-			// if (!this.issuerResults.find(r => r.category === item)) {
-			// 	// appending the results to the badgeResults array bound to the view template.
-			// 	this.issuerResults.push(new BadgeResult(badge, issuerResults.issuer));
-			// }
-
 			return true;
 
 		}
@@ -176,7 +171,7 @@ export class BadgeCatalogComponent extends BaseRoutableComponent implements OnIn
 		// 	.forEach(addIssuerToResults);
 		this.badges
 			.filter(MatchingAlgorithm.issuerMatcher(this.searchQuery))
-			.forEach(addIssuerToResultsByCategory);
+			.forEach(addBadgeToResultsByIssuer);
 
 		// this.allBadges
 		// 	.filter(MatchingAlgorithm.badgeMatcher(this._searchQuery))
@@ -216,7 +211,7 @@ class MatchingAlgorithm {
 	}
 }
 
-class MatchingIssuerCategory {
+class MatchingBadgeIssuer {
 	constructor(
 		public issuerName: string,
 		public badge,

--- a/src/app/catalog/components/badge-catalog/badge-catalog.component.ts
+++ b/src/app/catalog/components/badge-catalog/badge-catalog.component.ts
@@ -32,6 +32,7 @@ export class BadgeCatalogComponent extends BaseRoutableComponent implements OnIn
 	// issuers: Issuer[] = null;
 	badges: BadgeClass[] = null;
 	badgeResults: BadgeClass[] = null;
+	badgeResultsByIssuer: MatchingIssuerCategory[] = [];
 	order = 'asc';
 	//issuerToBadgeInfo: {[issuerId: string]: IssuerBadgesInfo} = {};
 
@@ -69,7 +70,13 @@ export class BadgeCatalogComponent extends BaseRoutableComponent implements OnIn
 	get searchQuery() { return this._searchQuery; }
 	set searchQuery(query) {
 		this._searchQuery = query;
-		// this.saveDisplayState();
+		this.updateResults();
+	}
+
+	private _groupByIssuer = false;
+	get groupByIssuer() {return this._groupByIssuer;}
+	set groupByIssuer(val: boolean) {
+		this._groupByIssuer = val;
 		this.updateResults();
 	}
 
@@ -118,9 +125,11 @@ export class BadgeCatalogComponent extends BaseRoutableComponent implements OnIn
 
 	changeOrder(order){
 		if(order === 'asc'){
-			this.badgeResults.sort((a,b) => a.name.localeCompare(b.name))
+			this.badgeResults.sort((a,b) => a.name.localeCompare(b.name));
+			this.badgeResultsByIssuer.forEach(r => r.badges.sort((a, b) => a.name.localeCompare(b.name)));
 		} else {
-			this.badgeResults.sort((a,b) => b.name.localeCompare(a.name))
+			this.badgeResults.sort((a,b) => b.name.localeCompare(a.name));
+			this.badgeResultsByIssuer.forEach(r => r.badges.sort((a, b) => b.name.localeCompare(a.name)));
 		}
 	}
 
@@ -129,19 +138,61 @@ export class BadgeCatalogComponent extends BaseRoutableComponent implements OnIn
 		let that = this;
 		// Clear Results
 		this.badgeResults = [];
+		this.badgeResultsByIssuer = [];
+		const badgeResultsByIssuerLocal = {};
 
-		var addIssuerToResults = function(item){
+		// var addIssuerToResults = function(item){
+		// 	that.badgeResults.push(item);
+		// }
+
+		var addIssuerToResultsByCategory = function(item){
+
 			that.badgeResults.push(item);
+			
+			let issuerResults = badgeResultsByIssuerLocal[item.issuerName];
+			
+			if (!issuerResults) {
+				issuerResults = badgeResultsByIssuerLocal[item.issuerName] = new MatchingIssuerCategory(
+					item.issuerName,
+					""
+				);
+
+				// append result to the issuerResults array bound to the view template.
+				that.badgeResultsByIssuer.push(issuerResults);
+			}
+
+			issuerResults.addBadge(item);
+
+			// if (!this.issuerResults.find(r => r.category === item)) {
+			// 	// appending the results to the badgeResults array bound to the view template.
+			// 	this.issuerResults.push(new BadgeResult(badge, issuerResults.issuer));
+			// }
+
+			return true;
+
 		}
+		// this.badges
+		// 	.filter(MatchingAlgorithm.issuerMatcher(this.searchQuery))
+		// 	.forEach(addIssuerToResults);
 		this.badges
 			.filter(MatchingAlgorithm.issuerMatcher(this.searchQuery))
-			.forEach(addIssuerToResults);
+			.forEach(addIssuerToResultsByCategory);
 
 		// this.allBadges
 		// 	.filter(MatchingAlgorithm.badgeMatcher(this._searchQuery))
 		// 	.forEach(addBadgeToResults);
 
 		this.badgeResults.sort((a,b) => a.name.localeCompare(b.name))
+		this.badgeResultsByIssuer.forEach(r => r.badges.sort((a, b) => a.name.localeCompare(b.name)));
+	}
+
+	private issuerIdToSlug(issuerId) {
+		if(issuerId.startsWith("http")) {
+			let splitted = (issuerId.split(/[/.\s]/))
+			return splitted[splitted.length-1]
+		} else {
+			return issuerId
+		}
 	}
 
 	openLegend(){
@@ -162,5 +213,21 @@ class MatchingAlgorithm {
 		return badge => (
 			StringMatchingUtil.stringMatches(badge.name, patternStr, patternExp)
 		);
+	}
+}
+
+class MatchingIssuerCategory {
+	constructor(
+		public issuerName: string,
+		public badge,
+		public badges: BadgeClass[] = [],
+	) {}
+
+	async addBadge(badge) {
+		if (badge.issuerName === this.issuerName) {
+			if (this.badges.indexOf(badge) < 0) {
+				this.badges.push(badge);
+			}
+		}
 	}
 }


### PR DESCRIPTION
This makes it possible to group badges by issuer/institution in the badges tab. I more or less copied the approach for [grouping issuers by categories](https://github.com/myBadges-org/badgr-ui/commit/5783e0e8b2c794bec446f46133e3bf232a9b5ba6).

I was also briefly thinking to save the state of the grouping like it is done in the backpack tab, but it didnt work when I tried to recreate it. And it seems to be a bit buggy too in the backpack, but maybe thats just in my localhost.