### PR TITLE
fix issuer link

### DIFF
--- a/src/app/catalog/components/badge-catalog/badge-catalog.component.html
+++ b/src/app/catalog/components/badge-catalog/badge-catalog.component.html
@@ -80,6 +80,7 @@
 						public="true"
 						[publicUrl]="badge.url"
 						[badgeClass]="true"
+						[issuerSlug]="badge.issuerSlug"
 					></bg-badgecard>
 				</div>
 			</ng-container>

--- a/src/app/common/components/bg-badgecard.ts
+++ b/src/app/common/components/bg-badgecard.ts
@@ -20,7 +20,10 @@ declare function require(path: string): string;
 			</div>
 			<a *ngIf="badgeSlug" class="badgecard-x-title u-text-breakword" [routerLink]="['../earned-badge', badgeSlug]">{{ badgeTitle }}</a>
 			<a *ngIf="publicUrl" class="badgecard-x-title" [href]="publicUrl">{{ badgeTitle }}</a>
-			<a class="badgecard-x-issuer" [routerLink]="['../../public/issuers', issuerSlug]">{{ issuerTitle }}</a>
+			<a *ngIf="issuerSlug; else noIssuerSlug" class="badgecard-x-issuer" [routerLink]="['../../public/issuers', issuerSlug]">{{ issuerTitle }}</a>
+			<ng-template #noIssuerSlug>
+				<div class="badgecard-x-issuer">{{ issuerTitle }}</div>
+			</ng-template>
 			<p class="badgecard-x-desc" [truncatedText]="badgeDescription" [maxLength]="100"></p>
 		</div>
 		<div class="badgecard-x-footer">


### PR DESCRIPTION
In the badge catalog the link to the issuer of a badge didnt work.
That was my fault, sorry. When I implemented that for the backpack, I didnt check which other components also used the badgecard component.

To note is, that there are two more components, which also use the badgecard, but the model of the badge in these components doesnt have an issuerslug. Thats why I made it so that if the issuerslug is undefined, the issuertitle will not be a link but a normal div.