### PR TITLE
fix nounproject and pdf export

### DIFF
--- a/src/app/common/components/formfield-image.ts
+++ b/src/app/common/components/formfield-image.ts
@@ -64,7 +64,7 @@ import { MessageService } from '../services/message.service';
 					<p class="dropzone-x-info1">Drag & Drop</p>
 					<p class="dropzone-x-info2">oder <span class="u-text-link">aus Dateien auswählen</span></p>
 					<!-- dont let user select icon when uploading badge -->
-					<p *ngIf="loaderName!='basic'" class="dropzone-x-info2">oder <span class="u-text-link" (click)="$event.preventDefault(); findNounproject($event)">online finden</span></p>
+					<p *ngIf="loaderName!='basic'" class="dropzone-x-info2">oder <span class="u-text-link" (click)="$event.preventDefault(); findNounproject($event)">Icon suchen</span></p>
 				</ng-container>
 			</label>
 

--- a/src/app/common/dialogs/export-pdf-dialog/export-pdf-dialog.component.css
+++ b/src/app/common/dialogs/export-pdf-dialog/export-pdf-dialog.component.css
@@ -4,6 +4,10 @@
 	padding: 10px 0;
 }
 
-.download-button {
-	
+#show-error-result {
+    text-align: center;
+    color: var(--color-error);
+    font-weight: bold;
+    font-size: var(--font-size-body);
+	padding: 10px 0;
 }

--- a/src/app/common/dialogs/export-pdf-dialog/export-pdf-dialog.component.html
+++ b/src/app/common/dialogs/export-pdf-dialog/export-pdf-dialog.component.html
@@ -14,7 +14,13 @@
 		</div>
 
 		<div class="category u-padding-xaxis3x u-margin-top2x warning">
-			<embed #outputPdf class="output-pdf-embed"/>
+			<embed #outputPdf class="output-pdf-embed" *ngIf="!pdfError; else showError"/>
+			<!-- No results error -->
+			<ng-template #showError>
+				<div id="show-error-result">
+					PDF konnte nicht erstellt werden...
+				</div>
+			</ng-template>
 			<div class="l-stack l-stack-right u-margin-top1x u-padding-bottom2x">
 				<button
 					type="submit"
@@ -22,6 +28,7 @@
 					(click)="downloadPdf()"
 					loading-message="Downloading..."
 					[disabled-when-requesting]="true"
+					[disabled]="pdfError"
 					>
 					Herunterladen
 				</button>

--- a/src/app/common/dialogs/export-pdf-dialog/export-pdf-dialog.component.ts
+++ b/src/app/common/dialogs/export-pdf-dialog/export-pdf-dialog.component.ts
@@ -23,6 +23,7 @@ export class ExportPdfDialog extends BaseDialog {
 	badgePdf: string | null = null;
 	doc: jsPDF = null;
 	themeColor: string;
+	pdfError: Error;
 
 	profile: UserProfile;
 
@@ -97,7 +98,8 @@ export class ExportPdfDialog extends BaseDialog {
 	}
 
 	generateSingleBadgePdf(badge: RecipientBadgeInstance) {
-		const badgeClass: ApiRecipientBadgeClass = badge.badgeClass
+		this.pdfError = undefined;
+		const badgeClass: ApiRecipientBadgeClass = badge.badgeClass;
 		this.doc = new jsPDF();
 
 		let yPos = 20;
@@ -107,158 +109,168 @@ export class ExportPdfDialog extends BaseDialog {
 		const pageHeight = this.doc.internal.pageSize.getHeight();
 		let cutoff = pageWidth - 27;
 
-		// image
-		const canvasWidth = 120;
-		const canvasHeight = 120;
-		const marginXImage = (pageWidth - canvasWidth) / 2;
-		this.doc.addImage(badgeClass.image, 'png', marginXImage, yPos, canvasWidth, canvasHeight);
+		try {
+			// image
+			const canvasWidth = 120;
+			const canvasHeight = 120;
+			const marginXImage = (pageWidth - canvasWidth) / 2;
+			let badge_img = new Image();
+			badge_img.src = badgeClass.image;
+			badge_img.crossOrigin = 'Anonymous';
+			this.doc.addImage(badge_img, 'JPEG', marginXImage, yPos, canvasWidth, canvasHeight);
 
-		// title
-		yPos += canvasHeight + 20;
-		this.doc.setFontSize(35);
-		this.doc.setFont('Helvetica', 'bold');
-		let title = badgeClass.name;
-		if(this.doc.getTextWidth(title) > cutoff) {
-			title = title.substring(0, title.length - (this.doc.getTextWidth(title)-cutoff)/2);
-			title += "..."
-		}
-		this.doc.text(title, pageWidth/2, yPos, {
-			align: 'center'
-		});
-
-		// subtitle
-		yPos += 20
-		this.doc.setFontSize(28);
-		this.doc.setFont('Helvetica', 'normal');
-		let subtitle = badgeClass.description;
-		if(this.doc.getTextWidth(subtitle) > cutoff) {
-			subtitle = subtitle.substring(0, subtitle.length - (this.doc.getTextWidth(subtitle)-cutoff)/4.2);
-			subtitle += "..."
-		}
-		this.doc.text(subtitle, pageWidth/2, yPos, {
-			align: 'center'
-		});
-
-		// line
-		yPos += 15
-		this.doc.setDrawColor(this.themeColor);
-		this.doc.setLineWidth(1.5);
-		this.doc.line(25, yPos, pageWidth-25, yPos)
-
-		// edge line
-		let edgeLineOffset = 8
-		this.doc.roundedRect(edgeLineOffset, edgeLineOffset, pageWidth-edgeLineOffset*2, pageHeight-edgeLineOffset*2, 5, 5)
-
-		// awarded to
-		yPos += 20
-		if(this.profile && 
-			((this.profile.firstName && this.profile.firstName.length > 0) || 
-			(this.profile.lastName && this.profile.lastName.length > 0))) {
-			let name = ""
-			if(this.profile.firstName) {
-				name += this.profile.firstName + " ";
-			}
-			if(this.profile.lastName) {
-				name += this.profile.lastName;
-			}
-			this.doc.setFontSize(20);
+			// title
+			yPos += canvasHeight + 20;
+			this.doc.setFontSize(35);
 			this.doc.setFont('Helvetica', 'bold');
-			let awardedToContentLength = this.doc.getTextWidth(name);
-			this.doc.setFontSize(18);
+			let title = badgeClass.name;
+			if(this.doc.getTextWidth(title) > cutoff) {
+				title = title.substring(0, title.length - (this.doc.getTextWidth(title)-cutoff)/2);
+				title += "..."
+			}
+			this.doc.text(title, pageWidth/2, yPos, {
+				align: 'center'
+			});
+
+			// subtitle
+			yPos += 20
+			this.doc.setFontSize(28);
 			this.doc.setFont('Helvetica', 'normal');
-			let awardedToLength = this.doc.getTextWidth("Awarded to: ");
-			if(awardedToContentLength+awardedToLength > cutoff) {
-				name = name.substring(0, name.length - (awardedToContentLength+awardedToLength-cutoff)/2);
-				name += "..."
+			let subtitle = badgeClass.description;
+			if(this.doc.getTextWidth(subtitle) > cutoff) {
+				subtitle = subtitle.substring(0, subtitle.length - (this.doc.getTextWidth(subtitle)-cutoff)/4.2);
+				subtitle += "..."
+			}
+			this.doc.text(subtitle, pageWidth/2, yPos, {
+				align: 'center'
+			});
+
+			// line
+			yPos += 15
+			this.doc.setDrawColor(this.themeColor);
+			this.doc.setLineWidth(1.5);
+			this.doc.line(25, yPos, pageWidth-25, yPos)
+
+			// edge line
+			let edgeLineOffset = 8
+			this.doc.roundedRect(edgeLineOffset, edgeLineOffset, pageWidth-edgeLineOffset*2, pageHeight-edgeLineOffset*2, 5, 5)
+
+			// awarded to
+			yPos += 20
+			if(this.profile && 
+				((this.profile.firstName && this.profile.firstName.length > 0) || 
+				(this.profile.lastName && this.profile.lastName.length > 0))) {
+				let name = ""
+				if(this.profile.firstName) {
+					name += this.profile.firstName + " ";
+				}
+				if(this.profile.lastName) {
+					name += this.profile.lastName;
+				}
 				this.doc.setFontSize(20);
 				this.doc.setFont('Helvetica', 'bold');
-				awardedToContentLength = this.doc.getTextWidth(name);
+				let awardedToContentLength = this.doc.getTextWidth(name);
+				this.doc.setFontSize(18);
+				this.doc.setFont('Helvetica', 'normal');
+				let awardedToLength = this.doc.getTextWidth("Awarded to: ");
+				if(awardedToContentLength+awardedToLength > cutoff) {
+					name = name.substring(0, name.length - (awardedToContentLength+awardedToLength-cutoff)/2);
+					name += "..."
+					this.doc.setFontSize(20);
+					this.doc.setFont('Helvetica', 'bold');
+					awardedToContentLength = this.doc.getTextWidth(name);
+					this.doc.setFontSize(18);
+					this.doc.setFont('Helvetica', 'normal');
+				}
+				this.doc.text("Awarded to: ", pageWidth/2 - (awardedToContentLength+awardedToLength)/2, yPos, {
+				});
+				this.doc.setFontSize(20);
+				this.doc.setFont('Helvetica', 'bold');
+				this.doc.text(name, pageWidth/2 + (awardedToContentLength+awardedToLength)/2 - awardedToContentLength, yPos, {
+				});
+			}
+
+			// issued by
+			yPos += 15
+			let issuedBy = badgeClass.issuer.name;
+			this.doc.setFontSize(20);
+			this.doc.setFont('Helvetica', 'bold');
+			let issuedByContentLength = this.doc.getTextWidth(issuedBy);
+			this.doc.setFontSize(18);
+			this.doc.setFont('Helvetica', 'normal');
+			let issuedByLength = this.doc.getTextWidth("Issued by: ..");
+			if(issuedByContentLength+issuedByLength > cutoff) {
+				issuedBy = issuedBy.substring(0, issuedBy.length - (issuedByContentLength+issuedByLength-cutoff)/2);
+				issuedBy += "..."
+				this.doc.setFontSize(20);
+				this.doc.setFont('Helvetica', 'bold');
+				issuedByContentLength = this.doc.getTextWidth(issuedBy);
 				this.doc.setFontSize(18);
 				this.doc.setFont('Helvetica', 'normal');
 			}
-			this.doc.text("Awarded to: ", pageWidth/2 - (awardedToContentLength+awardedToLength)/2, yPos, {
+			this.doc.text("Issued by: ", pageWidth/2 - (issuedByLength+issuedByContentLength)/2, yPos, {
 			});
-			this.doc.setFontSize(20);
+			this.doc.setFontSize(18);
 			this.doc.setFont('Helvetica', 'bold');
-			this.doc.text(name, pageWidth/2 + (awardedToContentLength+awardedToLength)/2 - awardedToContentLength, yPos, {
+			this.doc.text(issuedBy, pageWidth/2 + (issuedByLength+issuedByContentLength)/2 - issuedByContentLength, yPos, {
 			});
-		}
 
-		// issued by
-		yPos += 15
-		let issuedBy = badgeClass.issuer.name;
-		this.doc.setFontSize(20);
-		this.doc.setFont('Helvetica', 'bold');
-		let issuedByContentLength = this.doc.getTextWidth(issuedBy);
-		this.doc.setFontSize(18);
-		this.doc.setFont('Helvetica', 'normal');
-		let issuedByLength = this.doc.getTextWidth("Issued by: ..");
-		if(issuedByContentLength+issuedByLength > cutoff) {
-			issuedBy = issuedBy.substring(0, issuedBy.length - (issuedByContentLength+issuedByLength-cutoff)/2);
-			issuedBy += "..."
+			// issued on
+			yPos += 15
 			this.doc.setFontSize(20);
 			this.doc.setFont('Helvetica', 'bold');
-			issuedByContentLength = this.doc.getTextWidth(issuedBy);
+			let issuedOnContentLength = this.doc.getTextWidth(badge.issueDate.toLocaleDateString("uk-UK"));
 			this.doc.setFontSize(18);
 			this.doc.setFont('Helvetica', 'normal');
+			let issuedOnLength = this.doc.getTextWidth("Issued on: ");
+			this.doc.text("Issued on: ", pageWidth/2 - (issuedOnLength+issuedOnContentLength)/2, yPos, {
+			});
+			this.doc.setFontSize(20);
+			this.doc.setFont('Helvetica', 'bold');
+			this.doc.text(badge.issueDate.toLocaleDateString("uk-UK"), 
+				pageWidth/2 + (issuedOnLength+issuedOnContentLength)/2 - issuedOnContentLength, yPos, {
+			});
+
+			// logo
+			yPos += 15;
+			const logoWidth = 20;
+			const logoHeight = 20;
+			this.doc.setFontSize(18);
+			this.doc.setFont('Helvetica', 'normal');
+			let logoTextOnContentLength = this.doc.getTextWidth("bereitgestellt von my badges");
+			const marginXImageLogo = (pageWidth - logoWidth - logoTextOnContentLength) / 2;
+			var img = new Image()
+			img.src = 'assets/logos/Badges_Entwurf-15.png'
+			// this.doc.addImage(img, 'PNG', marginXImageLogo, yPos, logoWidth, logoHeight);
+			// this.doc.textWithLink("bereitgestellt von my badges", (pageWidth + logoWidth - logoTextOnContentLength) / 2, yPos + logoHeight * 2 / 3, {
+			// 	url: 'https://mybadges.org/public/start'
+			// });
+
+			this.doc.addImage(img, 'PNG', 25 - logoWidth/2, yPos, logoWidth, logoHeight);
+			this.doc.textWithLink("bereitgestellt von myBadges", 25 + logoWidth/2, yPos + logoHeight * 2 / 3, {
+				url: 'https://mybadges.org/public/start'
+			});
+
+			this.badgePdf = this.doc.output('datauristring');
+			this.outputElement.nativeElement.src = this.badgePdf
+				
+			this.outputElement.nativeElement.setAttribute('style', 'overflow: auto')
+		} catch(e) {
+			this.pdfError = e;
+			console.log(e)
 		}
-		this.doc.text("Issued by: ", pageWidth/2 - (issuedByLength+issuedByContentLength)/2, yPos, {
-		});
-		this.doc.setFontSize(18);
-		this.doc.setFont('Helvetica', 'bold');
-		this.doc.text(issuedBy, pageWidth/2 + (issuedByLength+issuedByContentLength)/2 - issuedByContentLength, yPos, {
-		});
-
-		// issued on
-		yPos += 15
-		this.doc.setFontSize(20);
-		this.doc.setFont('Helvetica', 'bold');
-		let issuedOnContentLength = this.doc.getTextWidth(badge.issueDate.toLocaleDateString("uk-UK"));
-		this.doc.setFontSize(18);
-		this.doc.setFont('Helvetica', 'normal');
-		let issuedOnLength = this.doc.getTextWidth("Issued on: ");
-		this.doc.text("Issued on: ", pageWidth/2 - (issuedOnLength+issuedOnContentLength)/2, yPos, {
-		});
-		this.doc.setFontSize(20);
-		this.doc.setFont('Helvetica', 'bold');
-		this.doc.text(badge.issueDate.toLocaleDateString("uk-UK"), 
-			pageWidth/2 + (issuedOnLength+issuedOnContentLength)/2 - issuedOnContentLength, yPos, {
-		});
-
-		// logo
-		yPos += 15;
-		const logoWidth = 20;
-		const logoHeight = 20;
-		this.doc.setFontSize(18);
-		this.doc.setFont('Helvetica', 'normal');
-		let logoTextOnContentLength = this.doc.getTextWidth("bereitgestellt von my badges");
-		const marginXImageLogo = (pageWidth - logoWidth - logoTextOnContentLength) / 2;
-		var img = new Image()
-		img.src = 'assets/logos/Badges_Entwurf-15.png'
-		// this.doc.addImage(img, 'PNG', marginXImageLogo, yPos, logoWidth, logoHeight);
-		// this.doc.textWithLink("bereitgestellt von my badges", (pageWidth + logoWidth - logoTextOnContentLength) / 2, yPos + logoHeight * 2 / 3, {
-		// 	url: 'https://mybadges.org/public/start'
-		// });
-
-		this.doc.addImage(img, 'PNG', 25 - logoWidth/2, yPos, logoWidth, logoHeight);
-		this.doc.textWithLink("bereitgestellt von myBadges", 25 + logoWidth/2, yPos + logoHeight * 2 / 3, {
-			url: 'https://mybadges.org/public/start'
-		});
-
-		this.badgePdf = this.doc.output('datauristring');
-		this.outputElement.nativeElement.src = this.badgePdf
-			
-		this.outputElement.nativeElement.setAttribute('style', 'overflow: auto')
 	}
 
 	// disclaimer: unfinished
 	generateBadgeCollectionPdf(collection: RecipientBadgeCollection) {
+		this.pdfError = undefined;
 		const badges: RecipientBadgeInstance[] = collection.badges
 		this.doc = new jsPDF();
 
 		let yPos = 20;
 		let xMargin = 10;
 
+		try {
 		// title
 		this.doc.setFontSize(30);
 		this.doc.setFont('Helvetica', 'bold');
@@ -354,15 +366,23 @@ export class ExportPdfDialog extends BaseDialog {
 
 		this.badgePdf = this.doc.output('datauristring');
 		this.outputElement.nativeElement.src = this.badgePdf
+
+		this.outputElement.nativeElement.setAttribute('style', 'overflow: auto')
+		} catch(e) {
+			this.pdfError = e;
+			console.log(e)
+		}
 	}
 
 	// disclaimer: unfinished
 	generateBackpackPdf(badgeResults: BadgeResult[], profile: UserProfile) {
+		this.pdfError = undefined;
 		this.doc = new jsPDF();
 
 		let yPos = 20;
 		let xMargin = 10;
 
+		try {
 		// title
 		this.doc.setFontSize(30);
 		this.doc.setFont('Helvetica', 'bold');
@@ -452,6 +472,11 @@ export class ExportPdfDialog extends BaseDialog {
 
 		this.badgePdf = this.doc.output('datauristring');
 		this.outputElement.nativeElement.src = this.badgePdf
+		this.outputElement.nativeElement.setAttribute('style', 'overflow: auto')
+		} catch(e) {
+			this.pdfError = e;
+			console.log(e)
+		}
 	}
 
 	downloadPdf() {

--- a/src/app/common/dialogs/nounproject-dialog/nounproject-dialog.component.html
+++ b/src/app/common/dialogs/nounproject-dialog/nounproject-dialog.component.html
@@ -68,7 +68,7 @@
 														class="button"
 														(click)="selectIcon(icon)"
 													>
-														Select
+														Auswählen
 													</button>
 												</td>
 											</tr>

--- a/src/app/common/dialogs/nounproject-dialog/nounproject-dialog.component.html
+++ b/src/app/common/dialogs/nounproject-dialog/nounproject-dialog.component.html
@@ -24,7 +24,7 @@
 							type="text"
 							name="forminput"
 							id="forminput"
-							placeholder="Badges durchsuchen"
+							placeholder="Icon suchen"
 							(ngModel)="searchQuery"
 						/>
 						<svg class="forminput-x-icon" icon="icon_search"></svg>
@@ -44,7 +44,7 @@
 								<tbody class="datatable-x-body">
 										<!-- Icons -->
 										<ng-template ngFor let-icon [ngForOf]="icons" let-i="index">
-											<tr class="datatable-x-row">
+											<tr class="datatable-x-row u-cursor-pointer" (click)="selectIcon(icon)">
 												<td class="datatable-x-cell">
 													<div class="l-flex l-flex-2x l-flex-aligncenter">
 														<img
@@ -54,11 +54,11 @@
 															[error-src]="badgeFailedImageUrl"
 															[loaded-src]="icon.preview_url"
 														/> 
-														<a
-															class="u-text u-text-link u-text-breakword"
+														<p
+															class="u-text-bold u-text-breakword"
 															[routerLink]=""
 															(click)="selectIcon(icon)"
-															>{{ icon.term }}</a
+															>{{ icon.term }}</p
 														>
 													</div>
 												</td>
@@ -75,11 +75,11 @@
 										</ng-template>
 								</tbody>
 								<div *ngIf="!endOfResults" id="load-more-icons">
-									<div *ngIf="loadingMore; else NotLoadingMore" class="u-text u-text-breakword">Loading...</div>
+									<div *ngIf="loadingMore; else NotLoadingMore" class="u-text u-text-breakword">Lädt...</div>
 									<ng-template #NotLoadingMore>
 										<a class="u-text u-text-link u-text-breakword"
 										[routerLink]=""
-										(click)="loadMoreIcons()">Load more...</a>
+										(click)="loadMoreIcons()">Mehr laden...</a>
 									</ng-template>
 								</div>
 							</table>
@@ -95,7 +95,7 @@
 				<!-- Language warning -->
 				<div class="category u-padding-xaxis3x u-margin-top2x warning">
 					<p>
-						Bitte nutze Englische Begriffe zum Suchen der Icons.
+						Bitte nutze englische Begriffe zum Suchen der Icons.
 					</p>
 				</div>
 			</div>


### PR DESCRIPTION
This fixes a few of the errors of pull request #28 and #26.

- When failing to create the pdf, the popup will show an error and disable the download button
- The link to the nounproject-searchbar-popup and the nounproject-searchbar now display "Icon suchen"
- The contents of the nounproject-searchbar-popup were translated to german
- Instead of displaying the name of an icon as a link, it is displayed as a text
- The whole row of an icon is clickable

What is still an issue:
- When the export-to-pdf function requests an image, it gives a cors error