### PR TITLE
some changes to the texts in the "create-badge" view

### DIFF
--- a/src/app/issuer/components/badgeclass-create/badgeclass-create.component.html
+++ b/src/app/issuer/components/badgeclass-create/badgeclass-create.component.html
@@ -6,10 +6,10 @@
 	</div>
 	<div class="l-containerxaxis topbar-x-wrap">
 		<div class="topbar-x-heading">
-			Create Badge
+			Badge erstellen
 		</div>
 		<div class="topbar-x-subheading">
-			You can award a badge to multiple recipients over time.
+			Du kannst eine Badge nach ihrer Erstellung an mehrere Empfänger vergeben.
 		</div>
 		<button
 			type="submit"

--- a/src/app/issuer/components/badgeclass-create/badgeclass-create.component.html
+++ b/src/app/issuer/components/badgeclass-create/badgeclass-create.component.html
@@ -9,7 +9,7 @@
 			Badge erstellen
 		</div>
 		<div class="topbar-x-subheading">
-			Du kannst eine Badge nach ihrer Erstellung an mehrere Empfänger vergeben.
+			Du kannst einen Badge nach der Erstellung an beliebig viele Empfänger vergeben.
 		</div>
 		<button
 			type="submit"

--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
@@ -13,12 +13,8 @@
 		<div class="formsection-x-help">
 			<h3 class="u-text-body-bold">Badge Basics</h3>
 			<p class="u-text u-margin-top1x u-margin-bottom2x">
-				Badge Bilder können entweder PNGs oder SVGs sein. Alle Angaben sind verpflichtend.
+				Badge Bilder können entweder PNGs oder SVGs oder die über die Iconsuche gewählten Icons sein. Um das gewählte Bild/Icon wird automatisch, je nach Kategorie, ein Rahmen gesetzt.
 			</p>
-			<a href="https://openbadges.org/" class="u-text-outlink"
-				>Finde mehr über Open Badges heraus
-				<svg icon="icon_external_link"></svg>
-			</a>
 			<br />
 			<a href="javascript:;" (click)="openLegend()" class="u-text-outlink"
 				>Was bedeuten die Rahmen und Farben?
@@ -148,7 +144,6 @@
 		</div>
 	</div>
 
-	<!-- Criteria Panel -->
 	<div class="formsection">
 		<div class="formsection-x-title">
 			<h2 class="u-text-dark2">Kategorie</h2>
@@ -157,9 +152,12 @@
 		<div class="formsection-x-help">
 			<h3 class="u-text-body-bold">Was ist die Kategorie?</h3>
 			<p class="u-text u-margin-top1x u-margin-bottom2x">
-				Als Kategorie wählst Du zwischen der Teilnahme, der Mitgliedschaft, einer fachlichen Kompetenz, einer
-				Metakompetenz oder einem Erfolg.
+				Als Kategorie wählst Du zwischen der Teilnahme/Erfolg, der Mitgliedschaft, einer fachlichen Kompetenz oder einer Metakompetenz.
 			</p>
+			<br />
+			<a href="javascript:;" (click)="openLegend()" class="u-text-outlink"
+				>Mehr zu den Kategorien
+			</a>
 		</div>
 		<div class="formsection-x-body">
 			<div class="forminput u-margin-bottom2x">
@@ -455,6 +453,15 @@
 					</button>
 				</li>
 			</ul>
+		</div>
+	</div>
+
+	<div class="formsection formsection-nohelp">
+		<div class="formsection-x-body">
+			<a href="https://openbadges.org/" class="u-text-outlink">
+				Finde mehr über Open Badges heraus
+				<svg icon="icon_external_link"></svg>
+			</a>
 		</div>
 	</div>
 


### PR DESCRIPTION
This deals with #30.

### I have a suggestion and a question:
**_Subtitle should be: Du kannst ein Badge an mehrere Empfänger vergeben._**
-> perhaps highlight, that the current view is for creating Badges, not for assigning them.
![image](https://user-images.githubusercontent.com/48286621/213883178-c785e209-eff3-48ed-8874-5895a52b508a.png)

**_bei Badge Basics den Text ergänzen: "Badge Bilder können entweder PNGs oder SVGs oder die über die Iconsuche gewählten Icons sein. Um das gewählte Bild/Icon wird automatisch, je nach Kategorie, ein Rahmen gesetzt. Was bedeuten die Rahmen und Farben? (mit URL wie jetzt schon). "[Finde mehr über Open Badges heraus" ganz ans Ende dann als URL aber in neuem Tab!._**
-> The link in a new tab like this?
![image](https://user-images.githubusercontent.com/48286621/213883245-55488eda-022d-4d20-8250-4d08e9e37e2b.png)